### PR TITLE
Adding SQLfluff to help support flyway check -code

### DIFF
--- a/ubuntu-2004/Dockerfile
+++ b/ubuntu-2004/Dockerfile
@@ -6,6 +6,9 @@ ARG FLYWAY_VERSION=7.7.1
 # https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04
 RUN apt-get update && apt-get install -y openjdk-11-jre-headless
 
+# Get SQL Fluff for Flyway Check Command
+RUN pip3 install sqlfluff==1.2.1
+
 # Change the workdir to flyway to install flyway binaries
 WORKDIR /flyway
 

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -6,6 +6,9 @@ ARG FLYWAY_VERSION=7.7.1
 # https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04
 RUN apt-get update && apt-get install -y openjdk-11-jre-headless
 
+# Get SQL Fluff for Flyway Check Command
+RUN pip3 install sqlfluff==1.2.1
+
 # Change the workdir to flyway to install flyway binaries
 WORKDIR /flyway
 

--- a/windows-2019/Dockerfile
+++ b/windows-2019/Dockerfile
@@ -5,6 +5,9 @@ SHELL ["powershell", "-Command"]
 
 ARG FLYWAY_VERSION=7.7.1
 
+# Get SQL Fluff for Flyway Check Command
+RUN pip3 install sqlfluff==1.2.1
+
 # # Install Flyway
 RUN Invoke-WebRequest "https://download.red-gate.com/maven/release/org/flywaydb/enterprise/flyway-commandline/${env:FLYWAY_VERSION}/flyway-commandline-${env:FLYWAY_VERSION}-windows-x64.zip" -OutFile flyway-cli.zip; `
     & '.\Program Files\7-Zip\7z.exe' x .\flyway-cli.zip; `


### PR DESCRIPTION
Flyway added the [check -code command line switch](https://documentation.red-gate.com/fd/check-concept-184127467.html).  Under the covers, it uses sqlfluff 1.21 (as specified by their documentation).  This PR will run the command to install sqlfluff on the flyway worker tools docker container.

![image](https://github.com/OctopusDeployLabs/flyway-workertools/assets/38642825/65cf7649-08f9-4ce2-a3ea-1a5c000a7026)
